### PR TITLE
Fix origin override for dimensions of same type

### DIFF
--- a/src/main/java/tauri/dev/jsg/config/stargate/StargateDimensionConfig.java
+++ b/src/main/java/tauri/dev/jsg/config/stargate/StargateDimensionConfig.java
@@ -83,7 +83,6 @@ public class StargateDimensionConfig {
 
     public static int getOrigin(int dimId, @Nullable BiomeOverlayEnum overlay) {
         if (overlay == null) overlay = BiomeOverlayEnum.NORMAL;
-        if (dim == null) return -1;
         if (dimensionMap == null) {
             try {
                 reload();

--- a/src/main/java/tauri/dev/jsg/config/stargate/StargateDimensionConfig.java
+++ b/src/main/java/tauri/dev/jsg/config/stargate/StargateDimensionConfig.java
@@ -81,9 +81,8 @@ public class StargateDimensionConfig {
         return reqFrom.isGroupEqual(reqTo);
     }
 
-    public static int getOrigin(DimensionType dimIn, @Nullable BiomeOverlayEnum overlay) {
+    public static int getOrigin(int dimId, @Nullable BiomeOverlayEnum overlay) {
         if (overlay == null) overlay = BiomeOverlayEnum.NORMAL;
-        DimensionType dim = fixDimType(dimIn);
         if (dim == null) return -1;
         if (dimensionMap == null) {
             try {
@@ -94,14 +93,10 @@ public class StargateDimensionConfig {
         }
         if (dimensionMap == null)
             return -1;
-        StargateDimensionConfigEntry entry = dimensionMap.get(dim.getId());
+        StargateDimensionConfigEntry entry = dimensionMap.get(dimId);
         if (entry == null) return -1;
         if (!entry.milkyWayOrigins.containsKey(overlay)) return -1;
         return entry.milkyWayOrigins.get(overlay);
-    }
-
-    private static DimensionType fixDimType(DimensionType type) {
-        return type.getName().equals("Nether") && type.getId() == -1 ? DimensionType.NETHER : type;
     }
 
     public static boolean netherOverworld8thSymbol() {

--- a/src/main/java/tauri/dev/jsg/tileentity/stargate/StargateClassicBaseTile.java
+++ b/src/main/java/tauri/dev/jsg/tileentity/stargate/StargateClassicBaseTile.java
@@ -1807,7 +1807,7 @@ public abstract class StargateClassicBaseTile extends StargateAbstractBaseTile i
 
         if (overlay == null) overlay = BiomeOverlayEnum.NORMAL;
 
-        int override = StargateDimensionConfig.getOrigin(DimensionManager.getProviderType(dimId), overlay);
+        int override = StargateDimensionConfig.getOrigin(dimId, overlay);
         if (override >= 0)
             return override;
 


### PR DESCRIPTION
When attempting to create a modpack with Advanced Rocketry - Reworked and JSG the points of origin were not overriding correctly. Advanced Rocketry creates all its "Planet" dimensions under the type "Planet." This resulted in the override for **every** planet being the first one defined in Advanced Rocketry. 

By changing the lookup from deriving by dimension type to dimension Id the issue was resolved and every planet could have its own point of origin.

As a result of doing so, the fixDimType function was not needed/compiling resulting in its removal.

I don't know if there was a good reason for the override lookup to be by dimension type and I only did **limited testing**.